### PR TITLE
Fix tensor_quant_flatten for non rank 3 inputs + Use opt level 0 for calib

### DIFF
--- a/python/tvm/relay/backend/contrib/tidl.py
+++ b/python/tvm/relay/backend/contrib/tidl.py
@@ -965,7 +965,7 @@ def tensor_quant_flatten(input_tensor, data_layout):
     # only use 1 batch for calibration
     input_tensor = input_tensor[0,:]
     # change layout to CxHxW to use numpy.flattern to change to 1-d array
-    if data_layout == "NHWC":
+    if data_layout == "NHWC" and len(input_tensor.shape) == 3:
         input_tensor = input_tensor.transpose(2,0,1)
 
     if np.amin(input_tensor) >= 0:

--- a/python/tvm/relay/backend/contrib/tidl.py
+++ b/python/tvm/relay/backend/contrib/tidl.py
@@ -1183,7 +1183,8 @@ def generate_subgraph_tensors(mod, params, input_node, input_data):
     print("Input map:", my_mutator.name_map)
 
     # Build and execute calibration graph to get outputs
-    with relay.build_config(opt_level=3):
+    # Use opt_level=0 to avoid optimizations which modify the module (could change original module)
+    with relay.build_config(opt_level=0):
         graph, lib, params = relay.build(mod_tvm, "llvm", params=params)
     mod = graph_runtime.create(graph, lib, ctx=tvm.cpu(0))
     mod.set_input(input_node, input_data)


### PR DESCRIPTION
1. If data layout is NHWC and an input is not rank 3, transpose in tensor_quant_flatten would cause an error.

2. Use opt level 0 when building calibration graph to avoid optimization which modify the module. Since TVM doesn't do a deep copy of the model, some particular optimizations bleed over into the original module which we use later.