### PR TITLE
[TIDL] Add reduce subgraph size pass

### DIFF
--- a/python/tvm/relay/backend/contrib/tidl.py
+++ b/python/tvm/relay/backend/contrib/tidl.py
@@ -222,6 +222,9 @@ def tensor_quant_flatten(input_tensor, data_layout):
     return output, scale, sign
 
 class VarReplacer(ExprMutator):
+    """
+    Replaces vars in expr according to var_map.
+    """
     def __init__(self, var_map):
         ExprMutator.__init__(self)
         self.var_map = var_map
@@ -247,10 +250,7 @@ def UnpackComposites(mod, compiler="tidl"):
             return super().visit_call(call)
 
     for func in mod.get_global_vars():
-        name = func.name_hint
-        if not mod[name].attrs or mod[name].attrs["Compiler"] != compiler:
-            continue
-        mod[name] = Unpacker().visit(mod[name])
+        mod[func.name_hint] = Unpacker().visit(mod[func.name_hint])
     return mod
 
 class CalibrationGraphMutator(ExprMutator):
@@ -366,18 +366,42 @@ def generate_subgraph_tensors(tidl_target, mod, params, input_node, input_data):
 
     return subgraph_tensors
 
+class ExprReplacer(ExprMutator):
+    """
+    Replaces call nodes in expr according to call_map
+    """
+    def __init__(self, call_map):
+        ExprMutator.__init__(self)
+        self.call_map = call_map
+
+    def visit_call(self, call):
+        if call in self.call_map:
+            return self.call_map[call]
+        return super().visit_call(call)
+
 class VarRenamer(ExprMutator):
+    """
+    Renames vars to match the new subgraph name. Used when subgraphs are renamed starting from zero.
+    If subgraph was originally "tidl_34", it would have inputs named like "tidl_34_i0". 
+    IF new_subgraph_name is "tidl_0", pass will that input to "tidl_0_i0".
+    """
     def __init__(self, new_subgraph_name):
         ExprMutator.__init__(self)
         self.new_subgraph_name = new_subgraph_name
 
     def visit_var(self, var):
-        if "_".join(var.name_hint.split('_')[:2]) != self.new_subgraph_name:
+        # TODO: Make sure input isn't from a composite func.
+        # TODO: Doesn't account for tuple inputs (not possible due to PruneSubgraphsWithMoreThanOneInput)
+        if var.name_hint.startswith("tidl") and "_".join(var.name_hint.split('_')[:2]) != self.new_subgraph_name:
             new_var_name = self.new_subgraph_name + "_" + var.name_hint.split('_')[2]
             return relay.Var(new_var_name, var.checked_type)
         return super().visit_var(var)
 
 class SubgraphRemover(ExprMutator):
+    """
+    Removes subgraphs which are in the list subgraphs_to_remove and returns them back to regular
+    TVM compilation in main function.
+    """
     def __init__(self, subgraphs_to_remove, mod, new_mod, rename_starting_from_0=True):
         ExprVisitor.__init__(self)
         self.subgraphs_to_remove = subgraphs_to_remove
@@ -416,6 +440,223 @@ class SubgraphRemover(ExprMutator):
                     self.new_mod[subgraph_gv] = self.mod[name]
                 return subgraph_gv(*args)
         return super().visit_call(call)
+
+class SubgraphSizeCounter(ExprVisitor):
+    """
+    Pass to count size of subgraph, both number of layers and estimated total memory usage.
+    Used by SubgraphReducer pass.
+    """
+    def __init__(self):
+        ExprVisitor.__init__(self)
+        self.num_layers = 0
+        self.total_memory = 0
+
+    def get_total_memory_mb(self):
+        return self.total_memory / (1024.0 * 1024.0)
+
+    def visit_call(self, call):
+        # Don't visit composite function body.
+        for arg in call.args:
+            super().visit(arg)
+        self.num_layers += 1
+        # Add total size of weights (16 bits per)
+        for arg in call.args:
+            if isinstance(arg, tvm.relay.expr.Constant):
+                self.total_memory += 2 * np.prod(list(map(int, arg.checked_type.shape)))
+        # Add activation size (8 bits per)
+        if isinstance(call.checked_type, tvm.relay.TensorType):
+            self.total_memory += np.prod(list(map(int, call.checked_type.shape)))
+
+def FindCommonAncestor(expr0, expr1):
+    """
+    Find the closest common ancestor to expr0 and expr1.
+    Returns distance from both.
+    Used by SubgraphReducer pass.
+    """
+    class CommonAncestor(ExprVisitor):
+        """
+        Creates a map of node -> distance from expr
+        """
+        def __init__(self):
+            ExprVisitor.__init__(self)
+            self.ancestors_with_distance = {}
+            self.call_outputs = {}
+
+        def Find(self, expr):
+            self.ancestors_with_distance[expr] = 0
+            self.call_outputs[expr] = []
+            super().visit(expr)
+
+        def _update(self, expr, expr_inputs):
+            for arg in expr_inputs:
+                if arg in self.call_outputs and expr not in self.call_outputs[arg]:
+                    self.call_outputs[arg].append(expr)
+                else:
+                    self.call_outputs[arg] = [expr]
+
+            if expr in self.call_outputs and len(self.call_outputs[expr]) > 0:
+                self.ancestors_with_distance[expr] = max([self.ancestors_with_distance[output] for output in self.call_outputs[expr]]) + 1
+            else:
+                # Op did not have any outputs that we have already visited.
+                self.ancestors_with_distance[expr] = 0
+
+        def visit_tuple_getitem(self, tuplegetitem):
+            self._update(tuplegetitem, [tuplegetitem.tuple_value])
+            super().visit_tuple_getitem(tuplegetitem)
+
+        def visit_tuple(self, tup):
+            self._update(tup, tup.fields)
+            super().visit_tuple(tup)
+
+        def visit_call(self, call):
+            self._update(call, call.args)
+            # Don't visit function body 
+            # We don't care what's inside composite functions, we will just remove the whole func.
+            for arg in call.args:
+                super().visit(arg)
+
+    common0 = CommonAncestor()
+    common0.Find(expr0)
+    common1 = CommonAncestor()
+    common1.Find(expr1)
+    # Find common
+    first_common_ancestor = None
+    distance_to_0 = 999999
+    distance_to_1 = 999999
+    for node in common0.ancestors_with_distance:
+        if node in common1.ancestors_with_distance:
+            if common0.ancestors_with_distance[node] <= distance_to_0 and common1.ancestors_with_distance[node] <= distance_to_1:
+                first_common_ancestor = node
+                distance_to_0 = common0.ancestors_with_distance[node]
+                distance_to_1 = common1.ancestors_with_distance[node]
+    return first_common_ancestor, distance_to_0, distance_to_1
+
+class SubgraphReducer(ExprMutator):
+    """
+    Removes a single op from end of subgraphs which exceed max_num_layers or max_total_memory_mb.
+    If an op is removed, reduced will be set to True.
+    """
+    def __init__(self, mod, new_mod, max_num_layers=256, max_total_memory_mb=512, compiler="tidl"):
+        ExprVisitor.__init__(self)
+        self.mod = mod
+        self.new_mod = new_mod
+        self.max_num_layers = max_num_layers
+        self.max_total_memory_mb = max_total_memory_mb
+        self.compiler = compiler
+        self.reduced = False
+
+    def visit_call(self, call):
+        if isinstance(call.op, GlobalVar):
+            name = call.op.name_hint
+            if not self.mod[name].attrs or self.mod[name].attrs["Compiler"] != self.compiler:
+                return super().visit_call(call)
+            # Compute size of subgraph to see if we need to reduce it.
+            counter = SubgraphSizeCounter()
+            counter.visit(self.mod[name])
+            if counter.num_layers > self.max_num_layers or counter.get_total_memory_mb() > self.max_total_memory_mb:
+                # Mark that we have reduced the subgraph size.
+                self.reduced = True
+                # "Inline" the last op only back into new main function.
+                original_func = self.mod[name]
+                # Get last_op
+                last_op = original_func.body
+                last_op_args = []
+                if isinstance(last_op, tvm.relay.expr.Tuple):
+                    # Subgraph has multiple outputs!
+                    assert len(last_op.fields) == 2
+                    ancestor, dist0, dist1 = FindCommonAncestor(last_op.fields[0], last_op.fields[1])
+                    if dist0 == 0 and dist1 == 0:
+                        last_op_args = ancestor.args
+                    elif dist0 > dist1:
+                        # field[0] is further from LCA.
+                        # Remove it by replacing it with its args.
+                        # Keep field[1]
+                        last_op_args = []
+                        for arg in last_op.fields[0].args:
+                            if arg != last_op.fields[1]:
+                                last_op_args.append(arg)
+                        last_op_args.append(last_op.fields[1])
+                    elif dist1 >= dist0:
+                        # field[1] is further from LCA.
+                        # Remove it by replacing it with its args.
+                        # Keep field[0]
+                        last_op_args = [last_op.fields[0]]
+                        for arg in last_op.fields[1].args:
+                            if arg != last_op_args[0]:
+                                last_op_args.append(arg)
+                elif isinstance(last_op, tvm.relay.expr.Call):
+                    last_op_args = last_op.args
+                else:
+                    raise ValueError("Input to last op is not call or tuple")
+                # Gather new outputs of the subgraph - from removed op's inputs
+                # This map will map Expr to index in new_outputs tuple
+                #print('last_op_args', last_op_args)
+                new_outputs = []
+                last_op_input_to_new_output_map = {}
+                if len(last_op_args) > 1:
+                    for arg in last_op_args:
+                        # Skip weights
+                        if not isinstance(arg, tvm.relay.expr.Constant):
+                            new_outputs.append(arg)
+                            last_op_input_to_new_output_map[arg] = len(new_outputs) - 1
+                    if len(new_outputs) > 1:
+                        new_outputs_expr = relay.Tuple(new_outputs)
+                    elif len(new_outputs) == 1:
+                        new_outputs_expr = new_outputs[0]
+                    else:
+                        raise ValueError("No ops left in subgraph after reducing size")
+                else:
+                    new_outputs = [last_op_args[0]]
+                    new_outputs_expr = new_outputs[0]
+                subgraph_gv = relay.GlobalVar(name)
+
+                # construct new func without last_op
+                new_func = relay.Function(original_func.params, new_outputs_expr)
+                new_func = new_func.with_attr("Primitive", tvm.tir.IntImm("int32", 1))
+                new_func = new_func.with_attr("Inline", tvm.tir.IntImm("int32", 1))
+                new_func = new_func.with_attr("Compiler", self.compiler)
+                new_func = new_func.with_attr("global_symbol", name)
+                self.new_mod[subgraph_gv] = new_func
+                args = []
+                for arg in call.args:
+                    args.append(super().visit(arg))
+                new_expr = subgraph_gv(*args)
+                if len(new_outputs) > 1:
+                    call_map = {arg: relay.TupleGetItem(new_expr, index) for arg, index in last_op_input_to_new_output_map.items()}
+                else:
+                    call_map = {new_outputs[0]: new_expr}
+                new_expr = ExprReplacer(call_map).visit(last_op)
+
+                return new_expr
+            elif name != "main":
+                # Transfer subgraph to new mod without modifying
+                args = []
+                for arg in call.args:
+                    args.append(super().visit(arg))
+                subgraph_gv = relay.GlobalVar(name)
+                self.new_mod[subgraph_gv] = self.mod[name]
+                return subgraph_gv(*args)
+        return super().visit_call(call)
+
+def ReduceSubgraphSize(mod, compiler="tidl", max_num_layers=256, max_total_memory_mb=512):
+    """
+    Reduces size of subgraph to fit limitations.
+    """
+    # Counter just in case to avoid infinite loop.
+    sanity_counter = 10000
+    # SubgraphReducer removes one op if the subgraph is above the limits.
+    # Repeated call SubgraphReducer until no subgraphs are reduced.
+    while sanity_counter > 0:
+        new_mod = tvm.IRModule()
+        reducer = SubgraphReducer(mod, new_mod, max_num_layers, max_total_memory_mb)
+        new_mod['main'] = reducer.visit(mod["main"])
+        # If no subgraphs where reduced in size, we are done.
+        if not reducer.reduced:
+            return new_mod
+        mod = new_mod
+        # Avoid infinite loop.
+        sanity_counter -= 1
+    return mod
 
 def PruneSubgraphsWithMoreThanOneInput(mod, compiler="tidl"):
     subgraph_names_to_remove = []
@@ -1282,7 +1523,7 @@ class TIDLCompiler:
             Folder to hold TIDL artifacts
     """
 
-    def __init__(self, platform, version, **kwargs):
+    def __init__(self, platform, version, max_num_layers=256, max_total_memory_mb=512, **kwargs):
         if platform == "AM57" and version >= (6,3):
             for key in ('num_tidl_subgraphs', 'data_layout', 'artifacts_folder', 'tidl_tools_path'):
                 if key in kwargs:
@@ -1337,8 +1578,9 @@ class TIDLCompiler:
         mod = transform.AnnotateTarget(self.tidl_target)(mod)
         mod = transform.MergeCompilerRegions()(mod)
         mod = transform.PartitionGraph()(mod)
-        mod = UnpackComposites(mod, compiler=self.tidl_target)
         mod = PruneSubgraphsWithMoreThanOneInput(mod, compiler=self.tidl_target)
+        mod = ReduceSubgraphSize(mod, max_num_layers=max_num_layers, max_total_memory_mb=max_total_memory_mb, compiler=self.tidl_target)
+        mod = UnpackComposites(mod, compiler=self.tidl_target)
         mod = PruneSubgraphs(mod, compiler=self.tidl_target, num_subgraphs_to_keep=self.num_tidl_subgraphs)
 
         #============= Generate subgraph boundary tensors ==============

--- a/python/tvm/relay/backend/contrib/tidl.py
+++ b/python/tvm/relay/backend/contrib/tidl.py
@@ -1529,6 +1529,8 @@ class TIDLCompiler:
                 if key in kwargs:
                     setattr(self, key, kwargs[key])
             self.tidl_target = "tidl"
+            self.max_num_layers = max_num_layers
+            self.max_total_memory_mb = max_total_memory_mb
         else:
             sys.exit("Unsupported TIDL platform or version!")
 

--- a/python/tvm/relay/backend/contrib/tidl.py
+++ b/python/tvm/relay/backend/contrib/tidl.py
@@ -1598,7 +1598,7 @@ class TIDLCompiler:
         mod = transform.MergeCompilerRegions()(mod)
         mod = transform.PartitionGraph()(mod)
         mod = PruneSubgraphsWithMoreThanOneInput(mod, compiler=self.tidl_target)
-        mod = ReduceSubgraphSize(mod, max_num_layers=max_num_layers, max_total_memory_mb=max_total_memory_mb, compiler=self.tidl_target)
+        mod = ReduceSubgraphSize(mod, max_num_layers=self.max_num_layers, max_total_memory_mb=self.max_total_memory_mb, compiler=self.tidl_target)
         mod = UnpackComposites(mod, compiler=self.tidl_target)
         mod = PruneSubgraphs(mod, compiler=self.tidl_target, num_subgraphs_to_keep=self.num_tidl_subgraphs)
 

--- a/tests/python/relay/test_tidl_gluon.py
+++ b/tests/python/relay/test_tidl_gluon.py
@@ -1,0 +1,114 @@
+import os
+import sys
+import numpy as np
+from matplotlib import pyplot as plt
+
+import tvm
+import tvm.relay.testing
+from tvm import relay
+from tvm.contrib import cc
+from tvm.contrib import graph_runtime
+from tvm.contrib.download import download_testdata
+from tvm.relay.backend.contrib import tidl
+import mxnet as mx
+from mxnet import image
+from mxnet.gluon.model_zoo.vision import get_model
+import gluoncv
+
+def model_compile(model_name, mod_orig, params, input_data, num_tidl_subgraphs=4, 
+                  data_layout="NCHW", input_node="data"):
+    artifacts_folder = "./artifacts_" + model_name
+    if os.path.isdir(artifacts_folder):
+        filelist = [ f for f in os.listdir(artifacts_folder)]
+        for file in filelist:
+            os.remove(os.path.join(artifacts_folder, file))
+    else:
+        os.mkdir(artifacts_folder)
+
+    mod = tidl.EnableTIDL(mod_orig, params, num_tidl_subgraphs, 
+                          data_layout, input_node, input_data, 
+                          artifacts_folder, os.path.join(os.getenv("TIDL_TOOLS_PATH"), "eve_test_dl_algo_ref.out"))
+    # We expect somethign to be offloaded to TIDL.
+    assert mod is not None
+
+    target = "llvm -target=armv7l-linux-gnueabihf"
+    graph, lib, params = relay.build_module.build(mod, target=target, params=params)
+    path_lib = os.path.join(artifacts_folder, "deploy_lib.so")
+    path_graph = os.path.join(artifacts_folder, "deploy_graph.json")
+    path_params = os.path.join(artifacts_folder, "deploy_param.params")
+    cc_path = os.path.join(os.getenv("ARM_GCC_PATH"), "arm-linux-gnueabihf-g++")
+    lib.export_library(path_lib, cc=cc_path)
+    with open(path_graph, "w") as fo:
+      fo.write(graph)
+    with open(path_params, "wb") as fo:
+      fo.write(relay.save_param_dict(params))
+
+
+def test_tidl_gluon():
+    x = np.random.normal(0, 1, (1, 3, 224, 224)) #np.load(os.path.join(os.getenv("TIDL_TOOLS_PATH"), 'dog.npy'))
+    input_data = x/np.amax(np.abs(x))
+
+    def test_model(model, input_shape, dtype, use_tidl=True, num_iteration=1):
+        block = get_model(model, pretrained=True)
+        mod, params = relay.frontend.from_mxnet(block, shape={'data': input_shape}, dtype=dtype)
+        model_compile(model, mod, params, input_node='data', input_data=input_data)
+
+    latency = {}
+    models = [
+        'alexnet',
+        'resnet18_v1',
+        'resnet34_v1',
+        'resnet50_v1',
+        'resnet101_v1',
+        'resnet152_v1',
+        'resnet18_v2',
+        'resnet34_v2',
+        'resnet50_v2',
+        'resnet101_v2',
+        'resnet152_v2',
+        'squeezenet1.0',
+        'mobilenet0.25',
+        'mobilenet0.5',
+        'mobilenet0.75',
+        'mobilenet1.0',
+        'mobilenetv2_0.25',
+        'mobilenetv2_0.5',
+        'mobilenetv2_0.75',
+        'mobilenetv2_1.0',
+        'vgg11',
+        'vgg16',
+        'densenet121',
+        'densenet169',
+        'densenet201',
+    ]
+    
+    dtype = 'float32'
+    input_shape = (1, 3, 224, 224)
+    for model in models:
+        print('testing model:', model),
+        test_model(model, input_shape, dtype, use_tidl=True)
+
+def test_tidl_gluoncv():
+    def test_model(model, input_shape, dtype, use_tidl=True, num_iteration=1):
+        block = gluoncv.model_zoo.get_model(model, pretrained=True)
+        mod, params = relay.frontend.from_mxnet(block, shape={'data': input_shape}, dtype=dtype)
+
+        input_data = np.random.normal(0, 1, input_shape)
+        input_data = input_data/np.amax(np.abs(input_data))
+        model_compile(model, mod, params, input_node='data', input_data=input_data)
+
+    latency = {}
+    models = [
+        ('deeplab_resnet50_ade', (1, 3, 480, 480)),
+        ('deeplab_resnet101_ade', (1, 3, 480, 480)),
+        ('yolo3_mobilenet1.0_coco', (1, 3, 224, 224)),
+    ]
+    
+    dtype = 'float32'
+    for model, input_shape in models:
+        print('testing model:', model)
+        test_model(model, input_shape, dtype, use_tidl=True)
+
+if __name__ == "__main__":
+    test_tidl_gluon()
+    test_tidl_gluoncv()

--- a/tests/python/relay/test_tidl_reduce_subgraph_size.py
+++ b/tests/python/relay/test_tidl_reduce_subgraph_size.py
@@ -171,8 +171,9 @@ def test_reduce_subgraph_size_multiple_output():
     # Will remove 2nd conv2d.
     ref_mod = expected_2()
     reduced = ReduceSubgraphSize(create_graph(), max_num_layers=1, compiler="tidl")
+    print('reduced', reduced)
     assert tvm.ir.structural_equal(reduced, ref_mod, map_free_vars=True)
 
 if __name__ == '__main__':
-    test_reduce_subgraph_size_single_output()
+    #test_reduce_subgraph_size_single_output()
     test_reduce_subgraph_size_multiple_output()

--- a/tests/python/relay/test_tidl_reduce_subgraph_size.py
+++ b/tests/python/relay/test_tidl_reduce_subgraph_size.py
@@ -1,0 +1,178 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import numpy as np
+import tvm
+from tvm import relay
+from tvm.relay.build_module import bind_params_by_name
+from tvm.relay.backend.contrib.tidl import ReduceSubgraphSize
+from test_pass_partition_graph import set_func_attr
+
+def test_reduce_subgraph_size_single_output():
+    def create_graph():
+        ishape = (1, 3, 12, 12)
+        x = relay.var('tidl_i0', shape=ishape, dtype='float32')
+        y = relay.nn.relu(x)
+        out = relay.nn.relu(y)
+        func = relay.Function([x], out)
+        func = set_func_attr(func, "tidl", "tidl_0")
+        gv = relay.GlobalVar("tidl_0")
+
+        mod = tvm.IRModule()
+        mod[gv] = func
+        x_main = relay.var('x', shape=ishape, dtype='float32')
+        main_f = relay.Function([x_main], gv(x_main))
+        mod['main'] = main_f
+        return mod
+
+    def expected():
+        ishape = (1, 3, 12, 12)
+        x = relay.var('tidl_i0', shape=ishape, dtype='float32')
+        out = relay.nn.relu(x)
+        func = relay.Function([x], out)
+        func = set_func_attr(func, "tidl", "tidl_0")
+        gv = relay.GlobalVar("tidl_0")
+
+        mod = tvm.IRModule()
+        mod[gv] = func
+        x_main = relay.var('x', shape=ishape, dtype='float32')
+        call = gv(x_main)
+        out = relay.nn.relu(call)
+        main_f = relay.Function([x_main], out)
+        mod['main'] = main_f
+        return mod
+
+    ref_mod = expected()
+    reduced = ReduceSubgraphSize(create_graph(), max_num_layers=1, compiler="tidl")
+    assert tvm.ir.structural_equal(reduced, ref_mod, map_free_vars=True)
+
+def test_reduce_subgraph_size_multiple_output():
+    def create_graph():
+        ishape = (1, 32, 14, 14)
+        w1shape = (32, 1, 3, 3)
+        dtype = "float32"
+        data0 = relay.var("tidl_0_i0", shape=(ishape), dtype=dtype)
+        input0 = relay.var("tidl_0_i1", shape=(w1shape), dtype=dtype)
+        input1 = relay.var("tidl_0_i2", shape=(w1shape), dtype=dtype)
+        params = {"tidl_0_i1": np.ones(w1shape, dtype="float32"), "tidl_0_i2": np.ones(w1shape, dtype="float32")}
+        depthwise_conv2d_1 = relay.nn.conv2d(data0,
+                                             input0,
+                                             kernel_size=(3, 3),
+                                             padding=(1, 1),
+                                             groups=32)
+        depthwise_conv2d_2 = relay.nn.conv2d(depthwise_conv2d_1,
+                                             input1,
+                                             kernel_size=(3, 3),
+                                             padding=(1, 1),
+                                             groups=32)
+        out = relay.add(depthwise_conv2d_1, depthwise_conv2d_2)
+        func = relay.Function([data0, input0, input1], out)
+        func = set_func_attr(func, "tidl", "tidl_0")
+        func = bind_params_by_name(func, params)
+        gv = relay.GlobalVar("tidl_0")
+
+        mod = tvm.IRModule()
+        mod[gv] = func
+        x_main = relay.var('x', shape=ishape, dtype='float32')
+        main_f = relay.Function([x_main], gv(x_main))
+        mod['main'] = main_f #bind_params_by_name(main_f, params)
+        return mod
+   
+    def expected_1():
+        ishape = (1, 32, 14, 14)
+        w1shape = (32, 1, 3, 3)
+        dtype = "float32"
+        data0 = relay.var("tidl_0_i0", shape=(ishape), dtype=dtype)
+        input0 = relay.var("tidl_0_i1", shape=(w1shape), dtype=dtype)
+        input1 = relay.var("tidl_0_i2", shape=(w1shape), dtype=dtype)
+        params = {"tidl_0_i1": np.ones(w1shape, dtype="float32"), "tidl_0_i2": np.ones(w1shape, dtype="float32")}
+        depthwise_conv2d_1 = relay.nn.conv2d(data0,
+                                             input0,
+                                             kernel_size=(3, 3),
+                                             padding=(1, 1),
+                                             groups=32)
+        depthwise_conv2d_2 = relay.nn.conv2d(depthwise_conv2d_1,
+                                             input1,
+                                             kernel_size=(3, 3),
+                                             padding=(1, 1),
+                                             groups=32)
+        out = relay.Tuple([depthwise_conv2d_1, depthwise_conv2d_2])
+        func = relay.Function([data0, input0, input1], out)
+        func = set_func_attr(func, "tidl", "tidl_0")
+        func = bind_params_by_name(func, params)
+        gv = relay.GlobalVar("tidl_0")
+
+        mod = tvm.IRModule()
+        mod[gv] = func
+        x_main = relay.var('x', shape=ishape, dtype='float32')
+        call = gv(x_main)
+        get_output_0 = relay.TupleGetItem(call, 0)
+        get_output_1 = relay.TupleGetItem(call, 1)
+        out = relay.add(get_output_0, get_output_1)
+        main_f = relay.Function([x_main], out)
+        mod['main'] = bind_params_by_name(main_f, params)
+        return mod
+
+    def expected_2():
+        ishape = (1, 32, 14, 14)
+        w1shape = (32, 1, 3, 3)
+        dtype = "float32"
+        data0 = relay.var("tidl_0_i0", shape=(ishape), dtype=dtype)
+        input0 = relay.var("tidl_0_i1", shape=(w1shape), dtype=dtype)
+        input1 = relay.var("tidl_0_i2", shape=(w1shape), dtype=dtype)
+        params = {"tidl_0_i1": np.ones(w1shape, dtype="float32"), "tidl_0_i2": np.ones(w1shape, dtype="float32")}
+        depthwise_conv2d_1 = relay.nn.conv2d(data0,
+                                             input0,
+                                             kernel_size=(3, 3),
+                                             padding=(1, 1),
+                                             groups=32)
+        out = depthwise_conv2d_1
+        func = relay.Function([data0, input0, input1], out)
+        func = set_func_attr(func, "tidl", "tidl_0")
+        func = bind_params_by_name(func, params)
+        gv = relay.GlobalVar("tidl_0")
+
+        mod = tvm.IRModule()
+        mod[gv] = func
+        x_main = relay.var('x', shape=ishape, dtype='float32')
+        call = gv(x_main)
+        depthwise_conv2d_2 = relay.nn.conv2d(call,
+                                             input1,
+                                             kernel_size=(3, 3),
+                                             padding=(1, 1),
+                                             groups=32)
+        tup = relay.Tuple([call, depthwise_conv2d_2])
+        get_output_0 = relay.TupleGetItem(tup, 0)
+        get_output_1 = relay.TupleGetItem(tup, 1)
+        out = relay.add(get_output_0, get_output_1)
+        main_f = relay.Function([x_main, input1], out)
+        mod['main'] = bind_params_by_name(main_f, params)
+        return mod
+    
+    # Will remove add.
+    ref_mod = expected_1()
+    reduced = ReduceSubgraphSize(create_graph(), max_num_layers=2, compiler="tidl")
+    assert tvm.ir.structural_equal(reduced, ref_mod, map_free_vars=True)
+
+    # Will remove 2nd conv2d.
+    ref_mod = expected_2()
+    reduced = ReduceSubgraphSize(create_graph(), max_num_layers=1, compiler="tidl")
+    assert tvm.ir.structural_equal(reduced, ref_mod, map_free_vars=True)
+
+if __name__ == '__main__':
+    test_reduce_subgraph_size_single_output()
+    test_reduce_subgraph_size_multiple_output()


### PR DESCRIPTION
Adds method `ReduceSubgraphSize()` to reduce subgraph size so that they fit the provided limits on number of layers and memory usage.

Pass `SubgraphReducer` will remove a single op from subgraphs exceeding the limits.
Pass `SubgraphCounter` will count number of layers and memory usage for a subgraph.