### PR TITLE
Remove bn_tuple_get_item pattern, support tuple get item in ReduceSubgraphSize

### DIFF
--- a/tests/python/relay/test_tidl_reduce_subgraph_size.py
+++ b/tests/python/relay/test_tidl_reduce_subgraph_size.py
@@ -25,7 +25,7 @@ from test_pass_partition_graph import set_func_attr
 def test_reduce_subgraph_size_single_output():
     def create_graph():
         ishape = (1, 3, 12, 12)
-        x = relay.var('tidl_i0', shape=ishape, dtype='float32')
+        x = relay.var('tidl_0_i0', shape=ishape, dtype='float32')
         y = relay.nn.relu(x)
         out = relay.nn.relu(y)
         func = relay.Function([x], out)
@@ -41,7 +41,7 @@ def test_reduce_subgraph_size_single_output():
 
     def expected():
         ishape = (1, 3, 12, 12)
-        x = relay.var('tidl_i0', shape=ishape, dtype='float32')
+        x = relay.var('tidl_0_i0', shape=ishape, dtype='float32')
         out = relay.nn.relu(x)
         func = relay.Function([x], out)
         func = set_func_attr(func, "tidl", "tidl_0")
@@ -171,9 +171,119 @@ def test_reduce_subgraph_size_multiple_output():
     # Will remove 2nd conv2d.
     ref_mod = expected_2()
     reduced = ReduceSubgraphSize(create_graph(), max_num_layers=1, compiler="tidl")
-    print('reduced', reduced)
+    assert tvm.ir.structural_equal(reduced, ref_mod, map_free_vars=True)
+
+def test_reduce_subgraph_size_tuple_get_item():
+    def create_graph():
+        ishape = (1, 32, 14, 14)
+        w1shape = (32, )
+        dtype = "float32"
+        data0 = relay.var("tidl_0_i0", shape=(ishape), dtype=dtype)
+        input0 = relay.var("tidl_0_i1", shape=(w1shape), dtype=dtype)
+        input1 = relay.var("tidl_0_i2", shape=(w1shape), dtype=dtype)
+        input2 = relay.var("tidl_0_i3", shape=(w1shape), dtype=dtype)
+        input3 = relay.var("tidl_0_i4", shape=(w1shape), dtype=dtype)
+        input4 = relay.var("tidl_0_i5", shape=(w1shape), dtype=dtype)
+        input5 = relay.var("tidl_0_i6", shape=(w1shape), dtype=dtype)
+        input6 = relay.var("tidl_0_i7", shape=(w1shape), dtype=dtype)
+        input7 = relay.var("tidl_0_i8", shape=(w1shape), dtype=dtype)
+        params = {"tidl_0_i" + str(i): np.ones(w1shape, dtype="float32") for i in range(1, 9)}
+        r = relay.nn.relu(data0)
+        batch_norm_0 = relay.nn.batch_norm(r, input0, input1, input2, input3)
+        batch_norm_1 = relay.nn.batch_norm(r, input4, input5, input6, input7)
+        tup_get_0 = batch_norm_0[0]
+        tup_get_1 = batch_norm_1[0]
+        out = relay.Tuple([tup_get_0, tup_get_1])
+        func = relay.Function([data0, input0, input1, input2, input3, input4, input5, input6, input7], out)
+        func = set_func_attr(func, "tidl", "tidl_0")
+        func = bind_params_by_name(func, params)
+        gv = relay.GlobalVar("tidl_0")
+
+        mod = tvm.IRModule()
+        mod[gv] = func
+        x_main = relay.var('x', shape=ishape, dtype='float32')
+        main_f = relay.Function([x_main], gv(x_main))
+        mod['main'] = main_f #bind_params_by_name(main_f, params)
+        return mod
+
+    def expected():
+        ishape = (1, 32, 14, 14)
+        w1shape = (32, )
+        dtype = "float32"
+        data0 = relay.var("tidl_0_i0", shape=(ishape), dtype=dtype)
+        input0 = relay.var("tidl_0_i1", shape=(w1shape), dtype=dtype)
+        input1 = relay.var("tidl_0_i2", shape=(w1shape), dtype=dtype)
+        input2 = relay.var("tidl_0_i3", shape=(w1shape), dtype=dtype)
+        input3 = relay.var("tidl_0_i4", shape=(w1shape), dtype=dtype)
+        input4 = relay.var("tidl_0_i5", shape=(w1shape), dtype=dtype)
+        input5 = relay.var("tidl_0_i6", shape=(w1shape), dtype=dtype)
+        input6 = relay.var("tidl_0_i7", shape=(w1shape), dtype=dtype)
+        input7 = relay.var("tidl_0_i8", shape=(w1shape), dtype=dtype)
+        params = {"tidl_0_i" + str(i): np.ones(w1shape, dtype="float32") for i in range(1, 9)}
+        r = relay.nn.relu(data0)
+        func = relay.Function([data0], r)
+        func = set_func_attr(func, "tidl", "tidl_0")
+        func = bind_params_by_name(func, params)
+        gv = relay.GlobalVar("tidl_0")
+
+        mod = tvm.IRModule()
+        mod[gv] = func
+        x_main = relay.var('x', shape=ishape, dtype='float32')
+        call = gv(x_main)
+        batch_norm_0 = relay.nn.batch_norm(call, input0, input1, input2, input3)
+        batch_norm_1 = relay.nn.batch_norm(call, input4, input5, input6, input7)
+        tup_get_0 = batch_norm_0[0]
+        tup_get_1 = batch_norm_1[0]
+        out = relay.Tuple([tup_get_0, tup_get_1])
+        main_f = relay.Function([x_main, input0, input1, input2, input3, input4, input5, input6, input7], out)
+        mod['main'] = bind_params_by_name(main_f, params)
+        return mod
+    
+    ref_mod = expected()
+    reduced = ReduceSubgraphSize(create_graph(), max_num_layers=2, compiler="tidl")
+    assert tvm.ir.structural_equal(reduced, ref_mod, map_free_vars=True)
+
+def test_reduce_subgraph_size_three_outputs_fallback():
+    def create_graph():
+        ishape = (1, 32, 14, 14)
+        dtype = "float32"
+        data0 = relay.var("tidl_0_i0", shape=(ishape), dtype=dtype)
+        r = relay.nn.relu(data0)
+        r0 = relay.nn.relu(r)
+        r1 = relay.tanh(r)
+        r2 = relay.sin(r)
+        out = relay.Tuple([r0, r1, r2])
+        func = relay.Function([data0], out)
+        func = set_func_attr(func, "tidl", "tidl_0")
+        gv = relay.GlobalVar("tidl_0")
+
+        mod = tvm.IRModule()
+        mod[gv] = func
+        x_main = relay.var('x', shape=ishape, dtype='float32')
+        main_f = relay.Function([x_main], gv(x_main))
+        mod['main'] = main_f
+        return mod
+
+    def expected():
+        ishape = (1, 32, 14, 14)
+        dtype = "float32"
+        data0 = relay.var("x", shape=(ishape), dtype=dtype)
+        r = relay.nn.relu(data0)
+        r0 = relay.nn.relu(r)
+        r1 = relay.tanh(r)
+        r2 = relay.sin(r)
+        out = relay.Tuple([r0, r1, r2])
+
+        mod = tvm.IRModule()
+        mod['main'] = relay.Function([data0], out)
+        return mod
+    
+    ref_mod = expected()
+    reduced = ReduceSubgraphSize(create_graph(), max_num_layers=1, compiler="tidl")
     assert tvm.ir.structural_equal(reduced, ref_mod, map_free_vars=True)
 
 if __name__ == '__main__':
-    #test_reduce_subgraph_size_single_output()
+    test_reduce_subgraph_size_single_output()
     test_reduce_subgraph_size_multiple_output()
+    test_reduce_subgraph_size_tuple_get_item()
+    test_reduce_subgraph_size_three_outputs_fallback()


### PR DESCRIPTION
I had created a pattern of BatchNorm -> TupleGetItem(0) to make the SubgraphSizeReducer’s job much easier. However, it looks like the pattern matcher has some bugs with tuple get item and is unable to correctly match that pattern.
 
This PR removes that pattern and instead updating SubgraphSizeReducer to support TupleGetItem to solve the issue. I also added a fallback in cases where subgraph has >2 outputs and needs to be reduced.